### PR TITLE
Add basic map app

### DIFF
--- a/map/app.js
+++ b/map/app.js
@@ -1,0 +1,55 @@
+const map = L.map('map').setView([28.5, -82], 6);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 19,
+  attribution: '© OpenStreetMap'
+}).addTo(map);
+
+const markers = L.layerGroup().addTo(map);
+
+function parseCSV(text) {
+  const lines = text.trim().split(/\r?\n/);
+  const headers = lines[0].split(',').map(h => h.trim());
+  return lines.slice(1).map(row => {
+    const values = row.split(',');
+    const obj = {};
+    headers.forEach((h,i)=>{ obj[h]=values[i]; });
+    return obj;
+  });
+}
+
+async function loadDataset(url) {
+  try {
+    const res = await fetch(url);
+    const text = await res.text();
+    return parseCSV(text);
+  } catch(e) {
+    console.error('Failed to load dataset', e);
+    return [];
+  }
+}
+
+function updateMarkers(data) {
+  markers.clearLayers();
+  data.forEach(row => {
+    const lat = parseFloat(row.Latitude);
+    const lng = parseFloat(row.Longitude);
+    if(!isNaN(lat) && !isNaN(lng)) {
+      L.marker([lat,lng]).bindPopup(row.Location || 'Site').addTo(markers);
+    }
+  });
+}
+
+document.getElementById('datasetSelect').addEventListener('change', async (e) => {
+  const url = e.target.value;
+  if(!url) return;
+  const data = await loadDataset(url);
+  updateMarkers(data);
+});
+
+document.getElementById('fileInput').addEventListener('change', async (e) => {
+  const file = e.target.files[0];
+  if(!file) return;
+  const text = await file.text();
+  const data = parseCSV(text);
+  updateMarkers(data);
+});

--- a/map/index.html
+++ b/map/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Florida EJ Map</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+e2g3YpGPC1L1fMdGII4XESyqCC3vVMh1SrFY/T0I=" crossorigin=""/>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="controls">
+    <select id="datasetSelect">
+      <option value="">Select Dataset</option>
+      <option value="https://gainesville.dssdglobal.org/projects/ej-dashboard/hazardous_sites_small.csv">Hazardous Waste Sites</option>
+      <option value="https://gainesville.dssdglobal.org/projects/ej-dashboard/superfund_sites.csv">Superfund Sites</option>
+    </select>
+    <input type="file" id="fileInput" accept=".csv">
+  </div>
+  <div id="map"></div>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-pMprOw6Nsap0nZdFvRzJU4UutP2FpW3XkdZcJdrPCVU=" crossorigin=""></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/map/style.css
+++ b/map/style.css
@@ -1,0 +1,14 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+#controls {
+  padding: 10px;
+  background: #f0f0f0;
+  display: flex;
+  gap: 10px;
+}
+#map {
+  width: 100%;
+  height: calc(100vh - 60px);
+}


### PR DESCRIPTION
## Summary
- add a new folder `map` containing a simple mapping application
- implement plain Leaflet setup with dataset selection and CSV upload
- style the map

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68730a5d462083279bb0462b439495ab