### PR TITLE
Use local datasets and add dark themed map UI

### DIFF
--- a/map/app.js
+++ b/map/app.js
@@ -1,7 +1,7 @@
 const map = L.map('map').setView([28.5, -82], 6);
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
   maxZoom: 19,
-  attribution: '© OpenStreetMap'
+  attribution: '© OpenStreetMap contributors © CARTO'
 }).addTo(map);
 
 const markers = L.layerGroup().addTo(map);
@@ -52,4 +52,8 @@ document.getElementById('fileInput').addEventListener('change', async (e) => {
   const text = await file.text();
   const data = parseCSV(text);
   updateMarkers(data);
+});
+
+document.getElementById('menuToggle').addEventListener('click', () => {
+  document.getElementById('sideMenu').classList.toggle('open');
 });

--- a/map/index.html
+++ b/map/index.html
@@ -8,11 +8,13 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div id="controls">
+  <div id="menuToggle">&#9776;</div>
+  <div id="sideMenu">
+    <h1>Florida EJ Map</h1>
     <select id="datasetSelect">
       <option value="">Select Dataset</option>
-      <option value="https://gainesville.dssdglobal.org/projects/ej-dashboard/hazardous_sites_small.csv">Hazardous Waste Sites</option>
-      <option value="https://gainesville.dssdglobal.org/projects/ej-dashboard/superfund_sites.csv">Superfund Sites</option>
+      <option value="hazardous_sites_small.csv">Hazardous Waste Sites</option>
+      <option value="superfund_sites.csv">Superfund Sites</option>
     </select>
     <input type="file" id="fileInput" accept=".csv">
   </div>

--- a/map/style.css
+++ b/map/style.css
@@ -1,14 +1,52 @@
 body {
   margin: 0;
   font-family: Arial, sans-serif;
+  background: #1e1e1e;
+  color: #eee;
 }
-#controls {
-  padding: 10px;
-  background: #f0f0f0;
-  display: flex;
-  gap: 10px;
+
+#menuToggle {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  font-size: 24px;
+  cursor: pointer;
+  z-index: 1000;
+  color: #fff;
 }
+
+#sideMenu {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 250px;
+  background: #333;
+  padding: 20px;
+  box-sizing: border-box;
+  transform: translateX(-250px);
+  transition: transform 0.3s;
+  overflow-y: auto;
+  z-index: 999;
+}
+
+#sideMenu.open {
+  transform: translateX(0);
+}
+
+#sideMenu h1 {
+  margin-top: 0;
+  font-size: 20px;
+  color: #fff;
+}
+
+#sideMenu select,
+#sideMenu input[type="file"] {
+  width: 100%;
+  margin-bottom: 10px;
+}
+
 #map {
   width: 100%;
-  height: calc(100vh - 60px);
+  height: 100vh;
 }


### PR DESCRIPTION
## Summary
- switched dataset dropdown to load local CSV files
- restyled the map page with a dark theme and collapsible sidebar
- updated Leaflet base map to a dark tile layer
- added menu button toggling logic

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6873191955908327a14332d15a4045aa