### PR TITLE
Add dashboard charts for per capita demographics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Welcome to the FEJ Almanac Project repository.
 
 ## Agent Log
 
+2025-08-06: Added side-panel charts comparing proximal and distal buffers with per capita metrics and selectable demographic markers (OpenAI Assistant).
 2025-08-06: Updated Census API key and added error handling for failed requests in map/app.js (OpenAI Assistant).
 
 (Place new entries here, with the most recent at the top.)

--- a/map/index.html
+++ b/map/index.html
@@ -51,6 +51,15 @@
         <span id="distalValue">0.00</span>
       </details>
       <button id="demographicsBtn">Get Demographics</button>
+      <details id="chartPanel" open>
+        <summary>Demographic Chart</summary>
+        <label for="demographicSelect">Data Marker:</label>
+        <select id="demographicSelect">
+          <option value="B02001_003E" data-label="Black or African American">Black or African American</option>
+          <option value="B02001_002E" data-label="White">White</option>
+        </select>
+        <div id="chartContainer"><canvas id="demographicChart"></canvas></div>
+      </details>
       <details open>
         <summary>Search by Address</summary>
         <div id="search-container">
@@ -70,6 +79,7 @@
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/map/style.css
+++ b/map/style.css
@@ -44,8 +44,8 @@ body {
 }
 
 #sidePanel {
-  width: 250px;
-  background: #1B2636;
+  width: 300px;
+  background: #232F41;
   padding: 10px;
   box-sizing: border-box;
   overflow-y: auto;
@@ -198,4 +198,31 @@ details summary {
 
 #search-btn:hover {
   background: #1565C0;
+}
+
+#chartPanel {
+  background: #1B2636;
+  border-radius: 8px;
+  padding: 10px;
+}
+
+#chartPanel select {
+  width: 100%;
+  margin-top: 5px;
+  padding: 4px;
+  background: #333;
+  color: #fff;
+  border: 1px solid #555;
+  border-radius: 4px;
+}
+
+#chartContainer {
+  width: 100%;
+  height: 180px;
+  margin-top: 10px;
+}
+
+#chartContainer canvas {
+  width: 100% !important;
+  height: 100% !important;
 }


### PR DESCRIPTION
## Summary
- Add side-panel dashboard chart with selectable demographic markers
- Compare proximal vs distal buffer demographics in per-capita bar chart
- Style side panel for cleaner dashboard look

## Testing
- `node --version`
- `node --check map/app.js`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68939c270f3483278dafba2cfe95dbaf