### PR TITLE
Refactor side panel workflow and analysis flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Welcome to the FEJ Almanac Project repository.
 
 ## Agent Log
 
+2025-08-08: Reorganized side panel into step-based workflow with integrated data loading and search, added side-panel controls for selection, distances, demographics, and analysis, removed collapsible panel and map buttons, and added chart loading indicator (OpenAI Assistant).
 2025-08-07: Added dashboard fullscreen toggle, responsive side panel handle with expanded demographic options including income and education (OpenAI Assistant).
 2025-08-06: Added side-panel charts comparing proximal and distal buffers with per capita metrics and selectable demographic markers (OpenAI Assistant).
 2025-08-06: Updated Census API key and added error handling for failed requests in map/app.js (OpenAI Assistant).

--- a/map/index.html
+++ b/map/index.html
@@ -11,50 +11,41 @@
 </head>
 <body>
   <header class="top-bar">
-    <div id="hamburger">&#9776;</div>
     <h1>Environmental Hazard Dashboard</h1>
     <button id="fullscreenBtn">Full Screen</button>
     <button id="aboutBtn">About</button>
   </header>
   <div id="main">
-    <aside id="sidePanel" class="open">
-      <div id="panelHandle" class="panel-handle">&#10094;</div>
-      <details id="loadData">
-        <summary>Load from dataset</summary>
+    <aside id="sidePanel">
+      <details id="dataStep" open>
+        <summary>Step 1: Load or Search Data</summary>
         <ul>
           <li data-url="hazardous_sites_small.csv">Hazardous Waste Sites</li>
           <li data-url="superfund_sites.csv">Superfund Sites</li>
         </ul>
-      </details>
-      <details>
-        <summary>Upload dataset</summary>
         <input type="file" id="fileInput" accept=".csv,.geojson">
         <div><a href="template.csv" download>Download template CSV</a></div>
-      </details>
-      <details>
-        <summary>Selection Instructions</summary>
-        <div style="font-size: 12px; color: #666; padding: 5px;">
-          1. Load a dataset above<br>
-          2. Use layer control (top-right) to switch map styles<br>
-          3. Click individual markers to select them<br>
-          4. Selected markers turn red<br>
-          5. Set buffer distances below<br>
-          6. Click "Get Demographics" to analyze
+        <div id="search-container">
+          <input type="text" id="search-input" placeholder="Enter address, city, or zip...">
+          <button id="search-btn">Search</button>
         </div>
       </details>
-      <details id="bufferControl">
-        <summary>Select proximal buffer range (miles)</summary>
+      <details id="selectionStep" open>
+        <summary>Step 2: Select Markers</summary>
+        <div id="selectionCount">Selected Points: 0</div>
+        <button id="clearSelectionBtn">Clear Selection</button>
+      </details>
+      <details id="distanceStep" open>
+        <summary>Step 3: Set Buffer Distances</summary>
+        <label for="proximalSlider">Proximal (miles)</label>
         <input type="range" id="proximalSlider" min="0" max="20" value="0" step="0.25">
         <span id="proximalValue">0.00</span>
-      </details>
-      <details id="distalControl">
-        <summary>Select distal buffer range (miles)</summary>
+        <label for="distalSlider">Distal (miles)</label>
         <input type="range" id="distalSlider" min="0" max="100" value="0" step="0.25">
         <span id="distalValue">0.00</span>
       </details>
-      <button id="demographicsBtn">Get Demographics</button>
-      <details id="chartPanel" open>
-        <summary>Demographic Chart</summary>
+      <details id="demographicsStep" open>
+        <summary>Step 4: Choose Demographic</summary>
         <label for="demographicSelect">Data Marker:</label>
         <select id="demographicSelect">
           <option value="B03002_003E" data-label="Non-Hispanic White" data-total="B03002_001E" data-type="rate" data-variables="B03002_003E">Non-Hispanic White</option>
@@ -66,14 +57,11 @@
           <option value="B19013_001E" data-label="Median Household Income" data-type="median" data-variables="B19013_001E">Median Household Income</option>
           <option value="B15003_022E,B15003_023E,B15003_024E,B15003_025E" data-label="Bachelor's Degree or Higher" data-total="B15003_001E" data-type="rate" data-variables="B15003_022E,B15003_023E,B15003_024E,B15003_025E">Bachelor's Degree or Higher</option>
         </select>
-        <div id="chartContainer"><canvas id="demographicChart"></canvas></div>
       </details>
-      <details open>
-        <summary>Search by Address</summary>
-        <div id="search-container">
-          <input type="text" id="search-input" placeholder="Enter address, city, or zip...">
-          <button id="search-btn">Search</button>
-        </div>
+      <details id="analyzeStep" open>
+        <summary>Step 5: Analyze</summary>
+        <button id="analyzeBtn">Analyze</button>
+        <div id="chartContainer"><canvas id="demographicChart"></canvas></div>
       </details>
     </aside>
     <div id="map"></div>

--- a/map/style.css
+++ b/map/style.css
@@ -17,11 +17,6 @@ body {
   height: 50px;
 }
 
-#hamburger {
-  font-size: 24px;
-  margin-right: 1rem;
-  cursor: pointer;
-}
 
 .top-bar h1 {
   flex: 1;
@@ -51,36 +46,7 @@ body {
   padding: 10px;
   box-sizing: border-box;
   overflow-y: auto;
-  transition: transform 0.3s;
   position: relative;
-}
-
-#sidePanel.closed {
-  transform: translateX(-250px);
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-}
-
-.panel-handle {
-  position: absolute;
-  top: 10px;
-  right: -20px;
-  width: 20px;
-  height: 40px;
-  background: #1976D2;
-  color: #fff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  border-radius: 0 4px 4px 0;
-  font-size: 18px;
-}
-
-#sidePanel.closed .panel-handle {
-  right: -20px;
 }
 
 #map {
@@ -115,14 +81,13 @@ details summary {
   font-weight: bold;
 }
 
-#loadData li {
+#dataStep li {
   cursor: pointer;
   color: #B0BEC5;
   margin: 4px 0;
 }
 
-#bufferControl input[type=range],
-#distalControl input[type=range] {
+#distanceStep input[type=range] {
   width: 100%;
 }
 
@@ -222,13 +187,7 @@ details summary {
   background: #1565C0;
 }
 
-#chartPanel {
-  background: #1B2636;
-  border-radius: 8px;
-  padding: 10px;
-}
-
-#chartPanel select {
+#demographicsStep select {
   width: 100%;
   margin-top: 5px;
   padding: 4px;
@@ -275,10 +234,13 @@ body.fullscreen #map {
     width: 80%;
     z-index: 1000;
   }
-  #sidePanel.closed {
-    transform: translateX(-100%);
-  }
   .top-bar h1 {
     font-size: 16px;
   }
+}
+
+.loading {
+  text-align: center;
+  color: #ccc;
+  padding: 20px 0;
 }


### PR DESCRIPTION
## Summary
- Reorganized dashboard side panel into step-based workflow for loading data, selecting markers, setting distances, choosing demographics, and analyzing results
- Removed collapsible side panel and map overlay buttons in favor of persistent panel controls with clear-selection and analyze actions
- Added chart loading indicator when analyzing selected points

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893d489f7ec8327b4ce1ca248bb51cc