### PR TITLE
Bias address search to Florida and add selectable marker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Welcome to the FEJ Almanac Project repository.
 
 ## Agent Log
 
+2025-08-09: Biased address search to Florida and made search result marker selectable (OpenAI Assistant).
 2025-08-08: Reorganized side panel into step-based workflow with integrated data loading and search, added side-panel controls for selection, distances, demographics, and analysis, removed collapsible panel and map buttons, and added chart loading indicator (OpenAI Assistant).
 2025-08-07: Added dashboard fullscreen toggle, responsive side panel handle with expanded demographic options including income and education (OpenAI Assistant).
 2025-08-06: Added side-panel charts comparing proximal and distal buffers with per capita metrics and selectable demographic markers (OpenAI Assistant).

--- a/map/app.js
+++ b/map/app.js
@@ -443,12 +443,13 @@ document.getElementById('analyzeBtn').addEventListener('click', async () => {
 
 // Address Search Functionality
 let searchMarker;
+const FLORIDA_VIEWBOX = '-87.6349,31.000968,-79.974307,24.396308';
 
 async function searchAddress() {
   const query = document.getElementById('search-input').value;
   if (!query) return;
 
-  const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(query)}`;
+  const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(query)}&countrycodes=us&viewbox=${FLORIDA_VIEWBOX}`;
   const searchBtn = document.getElementById('search-btn');
   searchBtn.textContent = 'Searching...';
   searchBtn.disabled = true;
@@ -464,15 +465,14 @@ async function searchAddress() {
       map.flyTo(latLng, 14);
 
       if (searchMarker) {
+        if (searchMarker.isSelected) {
+          toggleMarkerSelection(searchMarker);
+        }
         map.removeLayer(searchMarker);
       }
 
-      searchMarker = L.marker(latLng, {
-        icon: L.divIcon({
-          className: 'search-result-marker',
-          html: '<div class="pulsating-dot"></div>'
-        })
-      }).addTo(map).bindPopup(`<b>Search Result:</b><br>${display_name}`).openPopup();
+      searchMarker = createMarker(latLng[0], latLng[1], { 'Search Result': display_name });
+      searchMarker.addTo(map).openPopup();
 
     } else {
       alert('Address not found. Please try a different search.');


### PR DESCRIPTION
## Summary
- bias address geocoding requests toward Florida by passing a Florida viewbox and US country code to Nominatim
- drop a standard Leaflet marker for search results that can be clicked to toggle selection and clears any previously selected search marker

## Testing
- `node --check map/app.js`

------
https://chatgpt.com/codex/tasks/task_e_6893eaa557b08327900343e3adc1cc54