### PR TITLE
feat: enhance report with site details and per-site chart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Welcome to the FEJ Almanac Project repository.
 
 ## Agent Log
 
+2025-08-15: Moved report map to top, added site names to legend, included distal per-point stats and per-site bar chart (OpenAI Assistant).
 2025-08-14: Treat negative Census values as no data and exclude them from averages (OpenAI Assistant).
 2025-08-09: Biased address search to Florida and made search result marker selectable (OpenAI Assistant).
 2025-08-08: Reorganized side panel into step-based workflow with integrated data loading and search, added side-panel controls for selection, distances, demographics, and analysis, removed collapsible panel and map buttons, and added chart loading indicator (OpenAI Assistant).


### PR DESCRIPTION
## Summary
- Move report map to the top and list selected sites with their names
- Compute distal statistics per site and display them in results table
- Add per-site bar chart comparing proximal and distal values

## Testing
- `node --check map/app.js`


------
https://chatgpt.com/codex/tasks/task_e_689f71807a0c83279d205b6e7cd2607b