### PR TITLE
Add health insurance and housing value markers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Welcome to the FEJ Almanac Project repository.
 
 ## Agent Log
 
+2025-08-15: Added health insurance coverage, median home value, and median gross rent options for socioeconomic analysis (OpenAI Assistant).
 2025-08-15: Moved report map to top, added site names to legend, included distal per-point stats and per-site bar chart (OpenAI Assistant).
 2025-08-14: Treat negative Census values as no data and exclude them from averages (OpenAI Assistant).
 2025-08-09: Biased address search to Florida and made search result marker selectable (OpenAI Assistant).

--- a/map/index.html
+++ b/map/index.html
@@ -57,8 +57,11 @@
           <option value="B03002_006E" data-label="Asian" data-total="B03002_001E" data-type="rate" data-variables="B03002_006E">Asian</option>
           <option value="B03002_005E" data-label="Native American" data-total="B03002_001E" data-type="rate" data-variables="B03002_005E">Native American</option>
           <option value="B03002_012E" data-label="Hispanic or Latino" data-total="B03002_001E" data-type="rate" data-variables="B03002_012E">Hispanic or Latino</option>
-          <option value="B03002_007E,B03002_008E,B03002_009E" data-label="Other (Non-Hispanic)" data-total="B03002_001E" data-type="rate" data-variables="B03002_007E,B03002_008E,B03002_009E">Other (Non-Hispanic)</option>
-        </select>
+            <option value="B03002_007E,B03002_008E,B03002_009E" data-label="Other (Non-Hispanic)" data-total="B03002_001E" data-type="rate" data-variables="B03002_007E,B03002_008E,B03002_009E">Other (Non-Hispanic)</option>
+            <option value="K202702_001E" data-label="Private Health Insurance" data-total="K202701_001E" data-type="rate" data-variables="K202702_001E">Private Health Insurance Coverage</option>
+            <option value="K202510_001E" data-label="Median Home Value" data-type="median" data-variables="K202510_001E">Median Home Value</option>
+            <option value="K202511_001E" data-label="Median Gross Rent" data-type="median" data-variables="K202511_001E">Median Gross Rent</option>
+          </select>
         <div style="margin-top:8px">
           <label for="acsYearSelect">ACS Year:</label>
           <select id="acsYearSelect">


### PR DESCRIPTION
## Summary
- expand socioeconomic Data Marker options with private health insurance coverage and housing value metrics (median home value and median gross rent)
- log addition in AGENTS log

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_689f982a10c08327b65282f188dface7